### PR TITLE
Manifest attributes for hiding virtual softkeys on touchscreen LG phones

### DIFF
--- a/manifest.mf
+++ b/manifest.mf
@@ -15,4 +15,7 @@ MIDlet-Landscape-Support: true
 // endif
 // ifdef LG
 MIDlet-Screen-Mode: Both
+LGE-MIDlet-Display-Nav-Keypad: no
+LGE-MIDlet-TargetLCD-Height: 800
+LGE-MIDlet-TargetLCD-Width: 480
 // endif


### PR DESCRIPTION
Tested working on KM900. While it runs J2ME apps at 240x400 upscaled to native 480x800 resolution (presumably for compatibility since 480x800 apps and games are rather uncommon), I have the screen size set to the latter res anyway as I don't know if the other 480x800 LG feature phones (namely GD900, GC900, and GD880*), as well as BL40 (which has the same resolution height) do the same thing. If that cause issues on other phones, then try resizing to 240x400 instead.

*This actually has 480x854 display, but since it has virtual call/multitask and end keys I'm quite sure the actual displayable size is about the same as the others.