### PR TITLE
Arabic translation

### DIFF
--- a/language/ar.jsonc
+++ b/language/ar.jsonc
@@ -1,0 +1,839 @@
+[
+    // Translation notes:
+    // - Any line that begins with a "//" is a comment and is ignored.
+    //   In this file, comments are used for explaining each string.
+    // - Write your translated string inside the two quotation marks.
+    // - If you need to use a quotation mark inside any of your translated
+    //   strings, write it as \" instead.
+    // - If the original string has any special formatting
+    //   (e.g. space at the beginning or end), keep the formatting the same.
+    // - For any Discord-specific terminology (e.g. servers), use the same
+    //   translated term that Discord officially uses for your language.
+
+    // Notes about softkey command labels:
+    // - Each softkey label has two variations, a short and a long one.
+    // - In this translation file, the short labels are listed above the long ones.
+    // - Short labels are used in places where there is limited screen space.
+    // - Keep short labels as short as possible, ideally below 10 characters.
+    //   If needed, you may use abbreviations.
+    // - If a long label is short enough to where it could be used as a
+    //   short label, use the same string for both labels.
+
+    // Placeholder file name shown when the name of an attachment in the attachment view screen could not be loaded.
+    "ملف غير مسمى",
+
+    // Title text for the attachment picker (native file picker) screen.
+    "تحديد مرفق",
+
+    // Softkey labels for going back to the previous screen.
+    "رجوع",
+    "رجوع",
+
+    // Softkey label for closing a menu.
+    // Currently used in the attachment picker for closing the whole picker (because there is also a "Back" softkey for going back one directory)
+    "إغلاق",
+    "إغلاق",
+
+    // Title text for attachment view screen.
+    "المرفقات",
+
+    // Softkey labels for refetching contents of channel view or attachment view.
+    "تحديث",
+    "تحديث",
+
+    // Softkey labels used in channel or DM list for marking the selected channel or DM as read.
+    "تعليم كمقروءة",
+    "تعليم كمقروءة",
+
+    // Softkey labels used in channel and DM lists for marking every DM or every channel in the currently shown server as read.
+    "تعليم الكل كمقروءة",
+    "تعليم الكل كمقروءة",
+
+    // Generic "Select" softkey labels.
+    "تحديد",
+    "تحديد",
+
+    // Softkey labels for sending a message in the currently open channel.
+    "إرسال",
+    "إرسالل رسالة",
+
+    // Softkey labels for sending a reply to the selected message.
+    "رد",
+    "رد",
+
+    // Softkey labels for sending an attachment in the currently open channel.
+    "تحميل",
+    "تحميل ملف",
+
+    // Softkey labels for copying the text content of the selected message.
+    "نسخ",
+    "نسخ المحتوى",
+
+    // Softkey labels for editing the selected message.
+    "تحرير",
+    "تحرير",
+
+    // Softkey labels for deleting the selected message.
+    "حذف",
+    "حذف",
+
+    // Softkey labels for selecting an URL in the selected message. This opens a screen where each URL found in the message is listed, and one can be selected to be opened in the device's browser.
+    "فتح رابط",
+    "فتح رابط",
+
+    // Channel view title suffix when reading older messages.
+    " (قديمة)",
+
+    // Text shown at the center of the channel view when it is empty (no messages).
+    "لا شيء لرؤيته هنا",
+
+    // Channel view banner text shown when reading older messages and a new message arrives via the gateway.
+    "التحديث لقراءة الرسائل الجديدة",
+
+    // Channel view banner text shown when a gateway disconnect occurred and an automatic reconnect is in progress.
+    "قيد إعادة الاتصال",
+
+    // Channel view banner shown when a message is being sent by the client.
+    "قيد إرسال الرسالة",
+
+    // Channel view banner shown when a message is being edited by the client.
+    "قيد تحرير الرسالة",
+
+    // Channel view banner shown when a message is being deleted by the client.
+    "قيد حذف الرسالة",
+
+    // Channel view banner shown when messages are being loaded, e.g. during a refresh or after a message was sent by the client.
+    "قيد تحميل الرسائل",
+
+    // Suffix for channel view banner text when one person is typing.
+    // Example: "aa is typing"
+    " يكتب",
+
+    // Suffix for channel view banner text when two or three people are typing.
+    // Example: "aa, bb, cc are typing"
+    " يكتبون",
+
+    // Suffix for channel view banner text when more than three people are typing.
+    // Example: "4 people are typing"
+    " من الناس يكتبون",
+
+    // Comma separator used to separate usernames in the channel view banner text shown when people are typing.
+    " و",
+
+    // Error messages shown when trying to upload a file, delete a message, or edit a message, and the current proxy server is a direct HTTPS-HTTP proxy (and not a Discord J2ME specific proxy)
+    "هذا الوكيل لا يدعم تحميل الملفات",
+    "هذا الوكيل لا يدعم حذف الرسائل",
+    "هذا الوكيل لا يدعم تحرير الرسائل",
+
+    // Error message shown when trying to open the native file picker and the device does not support the J2ME FileConnection API.
+    "FileConnection غير مدعوم",
+
+    // Button labels for navigating between pages of messages in the channel view. Try to keep these as long as (or shorter than) the English strings.
+    // In the old channel view, these are shown as softkey labels (these strings are short and long variations of each)
+    "أقدم",
+    "عرض الرسائل الأقدم",
+    "أحدث",
+    "عرض الرسائل الأحدث",
+    
+    // Parts of the button label for viewing attachments of a message.
+    // Examples: "View 1 attachment", "View 2 attachments"
+    "عرض ",
+    " مرفق",
+    " من المرفقات",
+
+    // Title for confirmation screen shown when deleting a message.
+    "حذف",
+
+    // Body text for confirmation screen shown when deleting a message.
+    "حذف هذه الرسالة؟",
+
+    // Generic softkey labels.
+    "نعم",
+    "نعم",
+    "لا",
+    "لا",
+    "حسنًا",
+    "حسنًا",
+
+    // Placeholder name shown when fetching the name of an item (e.g. message author or DM) failed.
+    "(غير معروف)",
+
+    // Placeholder shown when the recipient message of a reply does not have any text content.
+    "(لا محتوى)",
+
+    // Placeholder message content shown when a message does not have any content that is supported by Discord J2ME.
+    "(رسالة غير مدعومة)",
+
+    // Message content shown for a message that has been deleted.
+    "(رسالة محذوفة)",
+
+    // Title text for direct message search screen.
+    "البحث في الرسائل الخاصة",
+
+    // Guide text for text field in direct message search and "insert mention" screens.
+    "إدخال اسم المستخدم",
+
+    // Error message shown when the searched user was not found in the direct messages list. Discord J2ME cannot initiate DM conversations based on only a username, so this message asks the user to use another client.
+    "المستخدم لم يعثر عليه. محاولة إنشاء الرسالة الخاصة باستخدام عميل آخر.",
+
+    // Title text for direct message list.
+    "الرسائل الخاصة",
+
+    // Generic "Search" softkey label. Currently used for searching for usernames in direct messages and when inserting a mention/ping.
+    "بحث",
+    "بحث",
+
+    // Title text shown for all error message screens.
+    "خطأ",
+
+    // Title text shown for guild (server) selector.
+    "الخوادم",
+
+    // Title text shown for favorite servers list.
+    "المفضلة",
+
+    // Generic "Remove" softkey command. Currently used for removing a server from the favorites list.
+    "إزالة",
+    "إزالة",
+
+    // Softkey command for adding a server to the favorites list.
+    "تفضيل",
+    "إضافة إلى المفضلة",
+
+    // Text shown when the gateway disconnects due to an error with the heartbeat thread. As this error message is quite technical, you may simplify/generalize it to, for example, "connection error".
+    "خطأ في الاتصال: ",
+
+    // Error message shown when the supplied authentication token is invalid (HTTP Unauthorized).
+    "التحقق من رمزك المميز",
+
+    // Prefix of error message shown when the HTTP response has an error code.
+    // The full message consists of this string and the code itself,
+    // e.g. HTTP error 500
+    "خطأ HTTP ",
+
+    // Error message shown when trying to load attachments and the CDN URL hasn't been set (is empty).
+    "لم يتم تعريف عنوان شبكة توصيل المحتوى. المرفقات غير متاحة.",
+
+    // Parentheses. Don't change these unless your language uses a different writing system where a different type of parentheses is normally used.
+    " (",
+    ")",
+
+    // Softkey labels for showing a text attachment's contents within the app.
+    "عرض",
+    "عرض كنص",
+
+    // Softkey labels for showing an attachment in the device's built-in web browser.
+    "فتح",
+    "فتح في المتصفح",
+
+    // Generic "Loading..." text shown in loading screen and in "Insert mention" screen.
+    "قيد التحميل...",
+
+    // Loading screen text shown when an attachment is being sent.
+    "قيد الإرسال...",
+
+    // Error message prefix shown when an error occurs while uploading an attachment.
+    "خطأ أثناء إرسال الملف: ",
+    
+    // Generic "Skip" softkey label. Currently used for skipping an action in the key mapper.
+    "تخطي",
+    "تخطي",
+
+    // Key press prompt shown in hotkey mapper.
+    "الضغط على المفتاح المراد اسخدامه لأجل:",
+
+    // Names of hotkey actions shown in the key mapper.
+    // These are shown after the "Press the key to use for:" string.
+    // "going back" only applies to the chat view. 
+    "إرسال رسالة",
+    "الرد على رسالة",
+    "نسخ محتوى رسالة",
+    "تحديث الرسائل",
+    "العودة",
+
+    // Error message prefix shown when a key has been mapped to an action and the user tried to map the same key to another action. The name of the already mapped action (see above) is written after this prefix.
+    "هذا المفتاح مخطط بالفعل ليقوم ب",
+
+    // Title text shown in login screen.
+    "تسجيل الدخول",
+
+    // Proxy server warning message shown at the top of the login screen.
+    "استخدام فقط الوكلاء أنت على ثقة بهم!",
+
+    // Help message for finding your token. Shown in login screen above the token field.
+    "يمكن العثور على الرمز المميز (Token) من على أدوات تطوير متصفحك (ابحث/ي عن مساعدة عبر الإنترنت). استخدام حساب بديل مستحسن.",
+
+    // "Use Wi-Fi" option shown in login screen on BlackBerry devices.
+    "استخدام Wi-Fi",
+
+    // Labels of text fields shown in the login screen.
+    // You don't need to use these acronyms if they don't make sense in your language. Translations like "Server URL" and "Image server URL" are acceptable too.
+    "عنوان واجهة برمجة التطبيقات",
+    "عنوان شبكة توصيل المحتوى",
+    "عنوان البوابة",
+    "الرمز المميز",
+
+    // Softkey label for confirming the login options in the login screen.
+    "دخول",
+    "تسجيل الدخول",
+
+    // Softkey command for exiting the application.
+    "خروج",
+    "خروج",
+
+    // "Use gateway" option shown in login screen.
+    "استخدام بوابة",
+
+    // Label for radio button field for token sending options.
+    "إرسال الرمز على هيئة",
+
+    // Token sending options.
+    "Header (الافتراضي)",
+    "JSON",
+    "Query parameter",
+
+    // Error messages shown when trying to login and the token or API URL fields are empty.
+    "الرجاء إدخال رمزك المميز",
+    "الرجاء تحديد عنوان واجهة برمجة تطبيقات",
+
+    // Main menu items.
+    // "Log out" brings you back to the login screen where you enter your token and other login settings.
+    "الخوادم",
+    "المفضلة",
+    "الرسائل الخاصة",
+    "الضبط",
+    "تسجيل الخروج",
+
+    // Title text shown in "Insert mention" screen (for adding a ping when writing a message).
+    "إدخال ذِكر",
+
+    // Label shown for username search results in "Insert mention" screen. Shown if more than one user matches the username query.
+    "نتائج البحث",
+
+    // Message shown when the username query resulted in no matches in the "Insert mention" screen.
+    "لا نتيجة",
+
+    // Error message shown when selecting "Insert" in the "Insert mention" screen and none of the search results (radio buttons) were picked.
+    "المستخدم غير محدد",
+
+    // Prefix and suffix of status message shown when a user has been added to a group DM. The whole message is in the form "added X to the group"
+    "أضيف ",
+    " إلى المجموعة",
+
+    // Status message shown when a user has left a group DM.
+    "غادر المجموعة",
+
+    // Prefix and suffix of status message shown when a user has removed another user from a group DM. The whole message is in the form "removed X from the group".
+    "أزيل ",
+    " من المجموعة",
+
+    // Status messages.
+    "بدأ مكالمة",
+    "غير اسم المجموعة",
+    "غير أيقونة المجموعة",
+    "ثبت رسالة",
+    "انضم إلى الخادم",
+    "غزز الخادم",
+
+    // Prefix of status message shown when a user has boosted the server and the server has reached a certain boosting level. The level is appended to the end of this string, in the form "boosted the server to level X".
+    "عزز الخادم إلى المستوى ",
+
+    // Prefix of message content when the message is a sticker.
+    // The whole message is in the form of "(sticker: Name)"
+    "(ملصق: ",
+
+    // Placeholder name for a sticker when the sticker's name could not be fetched.
+    "غير معروف",
+
+    // Message timestamp hour-minute separator, day-month separator, and AM/PM indicators.
+    // Note: order of day and month cannot be changed currently
+    ":",
+    "/",
+    "ص",
+    "م",
+
+    // Softkey labels for inserting a mention/ping in the "send message" screen.
+    "ذِكر",
+    "إدخال ذِكر",
+
+    // Prefixes of title text for "send message" screen.
+    // The full title is in the form of "Send message (@user)" or "Send message (#channel)".
+    "إرسال رسالة (@",
+    "إرسال رسالة (#",
+
+    // Error message shown when trying to insert a mention into a message and the gateway connection is not active.
+    "مطلوب اتصال نشط بالبوابة",
+
+    // Title text for "copy message content" screen.
+    "نسخ رسالة",
+
+    // Title text for "edit message content" screen.
+    "تحرير رسالة",
+
+    // Title text for gateway disconnect prompt screen.
+    "غير متصلة",
+
+    // Main body text for gateway disconnect prompt screen.
+    "خطأ بالبوابة. هل تريد/ين إعادة الاتصال؟",
+
+    // Top label for disconnection message shown in gateway disconnect prompt screen. The disconnection message is either a message sent by the Discord gateway (such as "requesting client reconnect") or a Java exception.
+    "رسالة",
+
+    // Prefix for top body text shown in the reply form. The whole top text is in the form "Replying to @user". The contents of the recipient message are shown below this.
+    "ردًا على ",
+
+    // Top label for the message entry box in the reply form.
+    "رسالتك:",
+
+    // Checkbox for selecting whether to mention/ping the recipient. Shown in the reply form.
+    "ذكر المؤلف",
+
+    // Title text for settings menu.
+    "الضبط",
+
+    // Settings screen heading for themes section.
+    "الموضوع",
+
+    // Theme options.
+    "غامق",
+    "فاتح",
+    "أسود",
+
+    // Settings screen heading for miscellaneous user interface related settings.
+    "واجهة الاستخدام",
+
+    // Settings option for enabling the old channel view user interface (from version 1.1 and below).
+    // This is no longer used, so keep it as null.
+    null,
+
+    // Settings option for using 12-hour time format in timestamps.
+    "توقيت 12 ساعة",
+
+    // Settings option for using the Java-based file picker for sending attachments. If disabled, the web-based file picker is used.
+    "منتقي الملفات الأصلي",
+
+    // Settings option for automatically reconnecting to the gateway if the connection closes.
+    "إعادة اتصال تلقائي بالبوابة",
+
+    // Settings option for enabling icons in server and direct message lists.
+    "أيقونات الخوادم/الخاص",
+
+    // Settings option for enabling nickname role colors.
+    "ألوان الأسماء",
+
+    // Settings screen heading for message author font size.
+    "خط مؤلفو الرسائل",
+
+    // Font size options.
+    "صغير",
+    "متوسط",
+    "كبير",
+
+    // Settings screen heading for message content font size.
+    "خط محتويات الرسائل",
+
+    // Settings screen heading for message load count. This is the amount of messages that are loaded and shown at a time.
+    "عدد تحميل الرسائل",
+
+    // Settings screen heading for selecting attachment file format.
+    "صيغة المرفقات",
+
+    // Settings screen heading for maximum attachment size in pixels.
+    "حجم المرفقات الأقصى (بكسل)",
+
+    // Settings screen heading for profile picture shape.
+    // Note: The word "avatar" was used here because "profile picture shape" is too long to fit on one row on some phones, and I didn't want to shorten it as "PFP".
+    "شكل الآفاتارات",
+
+    // Settings options for profile picture shape. "Circle (HQ)" is circle but with anti-aliasing and smoothing enabled.
+    "مربع",
+    "دائري",
+    "دائري مصقول",
+
+    // Settings section for profile picture resolution.
+    "دقة الآفتارات",
+
+    // Settings options for profile picture resolution. Placeholder means the PFPs won't get downloaded, but instead a placeholder (username's initials) is shown.
+    "عنصر نائب فقط",
+
+    // Resolution options. Used for profile picture resolution and menu icon resolution.
+    "إيقاف",
+    "16 بكسل",
+    "32 بكسل",
+
+    // Settings section for menu icon size.
+    "حجم أيقونات القائمة (بكسل)",
+
+    // Settings section for controlling the display of reply messages.
+    "عرض الردود على أنها",
+    
+    // Settings option to show replies as only the recipient (in the form "Author -> Recipient").
+    "متلقاة فقط",
+
+    // Settings option to show replies with the whole recipient message.
+    "رسائل كاملة",
+
+    // Settings section for hotkey action management.
+    "مفاتيح الاختصار",
+
+    // Settings option to use "default" hotkeys. When enabled, the J2ME game actions (ABCD) are used for hotkey actions, instead of user-defined key bindings. I named it "default" due to the lack of a better term for people who aren't familiar with J2ME development.
+    "مفاتيح الاختصار الافتراضية",
+
+    // Softkey label for opening the key remapper in the settings menu. The long variant of the label is shown as the button text.
+    "خريطة المفاتيح",
+    "تخصيص مفاتيح الاختصار",
+
+    // Generic softkey labels. Currently used in settings menu.
+    "حفظ",
+    "حفظ",
+    "إلغاء",
+    "إلغاء",
+
+    // Error message shown when trying to open an URL (e.g. attachment)from the app, but the phone does not support opening URLs while keeping the app running in the background.
+    "يجب إغلاق التطبيق قبل فتح العنوان.",
+
+    // Prefix of error message shown when an error occurs when trying to open an URL.
+    "تعذر فتح العنوان (",
+
+    // Suffix of error message shown when an error occurs when trying to open an URL. The actual URL is shown after this message.
+    ")\n\nلربما عليك محاولة نسخ العنوان يدويًا إلى متصفح جهازك: ",
+
+    // Title text for URL list screen ('Open URL' option in channel view).
+    "تحديد عنوان",
+
+    // Softkey labels for inserting a mention in the "Insert mention" screen.
+    "إدخال",
+    "إدخال",
+
+    // Title for language selection screen.
+    "اللغة",
+
+    // Settings section for language options.
+    "اللغة",
+    
+    // Softkey labels for opening the language selection menu in the settings menu. The long variant of the label is shown as the button text.
+    "اللغة",
+    "تعيين اللغة",
+
+    // Softkey commands for toggling fullscreen mode in the chat view.
+    "ملء الشاشة",
+    "ملء الشاشة",
+
+    // Hotkey action for toggling fullscreen mode in the chat view. Shown in the key mapper.
+    // Related to "Names of hotkey actions shown in the key mapper" above.
+    "ملء الشاشة",
+
+    // Settings option for enabling fullscreen mode by default in the chat view.
+    "وضع ملء الشاشة",
+
+    // Settings section for selecting which kinds of messages notifications should be shown for.
+    "عرض إشعارات بخصوص",
+
+    // Options for the kinds of messages that notifications should be shown for.
+    "جميع الرسائل",
+    "الذِكر",
+    "الرسائل الخاصة",
+
+    // Text shown in notification alert windows. This is in the form of:
+    // User sent you a direct message: "message content"
+    // User sent a message in Server Name #channel: "message content"
+    " أرسل لك رسالة: \"",
+    " أرسل رسالة في ",
+
+    // Title for notification alert windows
+    "رسالة جديدة",
+
+    // Settings section for selecting which kinds of notification methods should be used for incoming messages.
+    "إخطاري عن طريق:",
+
+    // Options for the kinds of notification methods.
+    "نافذة تنبيه",
+    "صوت",
+
+    // Settings option for keeping server/channel lists in memory when pressing the Back button, so they don't have to be reloaded every time.
+    "إبقاء القنوات محملة",
+
+    // Text shown at the center of list screens when they are empty (no items).
+    // Note: in English, this is the same as the text shown when a channel view is empty ("Nothing to see here") but in some languages, that string was translated as something like "No messages", hence the need for a separate string for lists.
+    "لا شيء لرؤيته هنا",
+
+    // Main body text for gateway disconnect prompt screen.
+    // This string is shown when "gateway auto reconnect" setting is enabled and 3 reconnect attempts have failed.
+    "تعذر الاتصال بالبوابة. هل تريد/ين إعادة المحاولة؟",
+
+    // Softkey labels for sending an attachment as a reply to the selected message.
+    "تحميل رد",
+    "الرد بملف",
+
+    // Text shown in the reply form when a file is attached to the message that is currently being written. The name of the file is shown below this.
+    "الملف المرفق",
+
+    // Prefix and suffix for text shown in the notification alert window when the message has attachments.
+    // The whole text is shown as part of the message content and is in the form "(1 attachment)" or "(X attachments)"
+    "(",
+    " مرفق)",
+    " من المرفقات)",
+
+    // Settings section names/titles.
+    // "Language" title is defined above (see "Settings section for language options")
+    // "Behaviour" section is for miscellaneous options that don't fit anywhere else (e.g. message load count, auto gateway reconnect)
+    "المظهر",
+    "الصور",
+    "السلوك",
+    "الإشعارات",
+
+    // Settings option values shown below boolean (on/off, true/false) options in the settings menu.
+    // On large screens, these are instead shown on the right side of the options.
+    "إيقاف",
+    "تشغيل",
+
+    // Prefix and suffix for error message shown when an invalid value was entered into a textbox in the settings menu.
+    // This can occur if the given value is not a valid number, is less than 1, or is above the maximum value for that setting.
+    // The whole message is in the form of "Please enter a valid number between 1 and X"
+    // where X is the maximum value for that setting.
+    // In English, the suffix is not needed, so it's an empty string, "".
+    // If the "X" needs to be in the middle of the sentence in your language, use the suffix to write what goes after the "X".
+    "الرجاء إدخال رقم صالح بين 1 و",
+    "",
+
+    // Settings option for using nnproject's Pigler Notifications API (extension API for showing notifications in the notification panel on Symbian Belle) for message notifications. The name "Pigler" should not be translated.
+    "واجهة برمجة تطبيقات Pigler",
+
+    // Prefix for error messages related to Pigler Notifications API.
+    "خطأ بواجهة برمجة التطبيقات Pigler: ",
+    
+    // Error message shown when Pigler API support is not detected. This is shown every time on app startup if Pigler notifications are enabled in app settings, until either the option is disabled or Pigler support is installed on the device.
+    "واجهة برمجة إشعارات التطبيقات Pigler غير مدعومة. الرجاء تثبيت واجهة برمجة التطبيقات Pigler من على nnp.nnchan.ru/pna أو تعطيل إشعارات Pigler في الضبط.",
+
+    // Settings option for showing the scrollbar on the right side of the screen.
+    "شريط التمرير",
+
+    // Options for the "Show scroll bar" setting.
+    // "Off" (see "Settings option values shown below boolean") means the scroll bar is disabled, but content can still be scrolled by swiping anywhere on the screen.
+    // "Hidden" means the scroll bar is not shown until the user taps on the right edge of the screen. This is the default on most platforms.
+    // "Visible" means the scroll bar is always shown (decreasing the available horizontal screen space). This is the default on KEmulator.
+    "مخفي",
+    "مرئي",
+
+    // Main menu option for about/credits screen.
+    // Related to "Main menu items" above.
+    "حول",
+
+    // Title text for about screen.
+    "حول",
+
+    // Prefix for version line shown in the about screen. The app's version number is shown after this.
+    "الإصدار ",
+
+    // Heading shown in the about screen for developers.
+    "المطورون",
+
+    // Heading shown in the about screen for language translation authors. Shown below developers.
+    "المترجمون",
+
+    // Heading shown in the about screen for links to support groups (Discord server and Telegram group).
+    "الدعم",
+
+    // Lines shown in the about (credits) screen for what each developer (major contributor) did.
+    // The name of the person in question is shown above each line.
+    "المطور القائد",
+    "تحميل المرفقات وتكامل واجهة برمجة التطبيقات Pigler وتحليل JSON",
+    "فنانة شاشة التحميل وأيقونات القائمة والرموز التعبيرية والترجمة الإيطالية",
+
+    // Lines shown in the about screen for which language(s) each person wrote translations for.
+    // Note: These are ordered alphabetically based on the person's name, not the language's name
+    "الفيتنامية",
+    "السويدية",
+    "الإندونيسية",
+    "البولندية",
+    "الإسبانية",
+    "البرتغالية (البرازيلية)",
+    "التايلاندية",
+    "البرتغالية",
+    "الصينية (التقليدية) والكانتونية",
+    "الأوكرانية",
+    "الرومانية",
+    "التركية",
+    "الروسية",
+
+    // Softkey labels shown in notification alert window for opening/viewing the channel where the notification occurred.
+    "عرض",
+    "عرض",
+
+    // Settings option for automatically checking for updates on every startup of the app. If an update is found, a prompt is shown, which when confirmed, opens a browser to install the new version.
+    "التحديث التلقائي",
+
+    // Title for dialog box shown when an update was found.
+    "تحديث متاح",
+
+    // Parts of the body text shown in the update dialog box. The appropriate version numbers are inserted after "Current: " and "Latest: ".
+    "إصدارٌ جديد من Discord J2ME متاح. هل تريد/ين التحديث؟\nالحالي: ",
+    "\nالأحدث: ",
+
+    // Softkey labels for confirming an update in the update dialog box.
+    "تحديث",
+    "تحديث",
+
+    // Options for the "Auto update" setting.
+    // "Releases only" means the user is only notified for stable release versions, not betas/pre-release versions. "All versions" means the user is also notified for betas.
+    "المستقرة فقط",
+    "جميع الإصدارات",
+
+    // Related to "Lines shown in the about screen for which language" above.
+    "الألمانية",
+    "الكرواتية",
+
+    // Units for attachment sizes.
+    " بايت",
+    " ك.ب.",
+    " م.ب.",
+
+    // Softkey labels for opening the thread list of a channel in the channel list.
+    "نقاشات",
+    "عرض النقاشات",
+
+    // Softkey labels for entering a token in the login screen (if a token hasn't already been set). The long variant of the label is shown as the button text.
+    "تعيين",
+    "تعيين رمز مميز",
+
+    // Softkey labels for changing the token in the login screen (if a token has already been set). The long variant of the label is shown as the button text.
+    "تغيير",
+    "تغيير الرمز المميز",
+
+    // Option in notification settings for using Nokia UI API for notifications.
+    "واجهة استخدام Nokia",
+
+    // Option in notification settings for using Nokia UI API for notifications. This variant of the option is shown on J2ME Loader, because J2ME Loader shows Nokia UI notifications as Android notifications in the notification panel.
+    "إشعارات Android",
+
+    // Text shown in the red bar used for marking the last unread messages in the chat view.
+    "جديد",
+
+    // Prompt shown at the top of the image preview screen when selecting an attachment.
+    "تحميل هذه الصورة؟",
+
+    // Settings option for enabling/disabling image previews when selecting a file in the native attachment file picker.
+    "معاينة منتقي الملفات",
+
+    // Header shown at the top of every forwarded message.
+    "رسالة محولة:",
+
+    // Help texts shown in the login screen for how to open the token input text box.
+    "الضغط على مفتاح BlackBerry لتعيين رمزك المميز.",
+    "الضغط على مفتاح BlackBerry لتغيير رمزك المميز.",
+
+    // Error message shown when image previews are enabled in the native file picker, but there is not enough free RAM on the device to show a preview for the selected image.
+    "لا توجد ذاكرة كافية لعرض معاينة الصورة.",
+
+    // Settings option for enabling or disabling emoji display in chats.
+    "عرض الرموز التعبيرية",
+
+    // Option for "Show emoji" setting where only standard emoji are shown. Custom emoji from servers are not shown, and are displayed as text instead.
+    "التلقائية فقط",
+
+    // Option for "Show emoji" setting where all emoji are shown.
+    "جميعها",
+
+    // Softkey labels for importing the token (from a file) in the login screen. The long variant of the label is shown as the button text.
+    "استيراد",
+    "استيراد رمز مميز",
+
+    // Title text for the token import file picker screen.
+    "تحديد ملف الرمز المميز",
+
+    // Text shown in loading screen when emoji data is being downloaded or updated.
+    "قيد تنزيل الرموز التعبيرية...",
+
+    // Related to "Lines shown in the about screen for which language" above.
+    "الفرنسية",
+    "البلغارية",
+
+    // Settings option for toggling markdown text formatting support in chat (bold, italic, etc).
+    "تنسيق النصوص",
+
+    // Softkey labels for inserting an emoji in the "send message" screen.
+    "رمز تعبيري",
+    "إدخال رمز تعبيري",
+
+    // Title for emoji picker screen.
+    "تحديد رمز تعبيري",
+
+    // Prompt shown when opening the emoji picker and the emoji images have not been downloaded onto the device.
+    "تنزيل بيانات الرموز التعبيرية؟",
+
+    // Indicator shown at the end of messages which have been edited. If possible, this should be translated the same way that it's translated in the official Discord clients.
+    "(محررة)",
+
+    // Softkey command for inserting a '_' character in the token input screen. Some devices don't have a built-in way to insert a '_'.
+    "شرطة_سفلية",
+    "إدخال شرطة_سفلية",
+
+    // Related to "Lines shown in the about (credits) screen for what each developer" above.
+    "صوت الإشعارات",
+
+    // Settings option for toggling vibration alert for notifications.
+    "الاهتزاز",
+
+    // Softkey command (short label and long label) for muting a channel/server/etc. or unmuting if it is already muted.
+    // For technical reasons it's easier to have one label for "mute/unmute" rather than separate "Mute" and "Unmute" labels that change dynamically.
+    // The short "Mute" label is also shown for unmuting. The long label can also be just "Mute" if "mute/unmute" doesn't make sense in your language.
+    "كتم",
+    "كتم/إلغاء الكتم",
+
+    // Hotkey actions for instantly moving to the top or bottom of the chat view. Related to "Names of hotkey actions shown in the key mapper" above.
+    "التمرير إلى أعلى",
+    "التمرير إلى أسفل",
+
+    // Settings option for toggling whether to send the typing indicator, i.e. show other people that you are typing when you select "Send message" or "Upload file".
+    "إرسال مؤشر الكتابة",
+
+    // Softkey command labels for applying an attached audio file as the in-app notification sound. The long variant of the label is shown on the button in the attachment view screen.
+    "استخدامه",
+    "استخدامه كصوت الإشعارات",
+
+    // Prompt shown when applying a new notification sound. The sound is played at the same time as the prompt appears.
+    "تطبيق هذا كصوت الإشعارات؟",
+
+    // Softkey command for playing the notification sound again in the aforementioned prompt.
+    "تشغيل",
+    "إعادة التشغيل",
+
+    // Confirmation message shown when a new notification sound has been set.
+    "تم تطبيق صوت الإشعارات!",
+
+    // Title for data manager screen. Data manager screen is used for viewing memory usage of application data and deleting parts of the app data if needed.
+    "إدارة البيانات",
+
+    // Types of data shown in the data manager:
+
+    // Downloaded image data of default emojis (not custom server emojis)
+    "صور الرموز التعبيرية",
+    // Timestamps of last read messages for each channel, used for handling unread message indicators.
+    "آخر الرسائل المقروءة",
+    // Custom sound file applied as the notification sound via a message attachment.
+    "صوت الإشعارات",
+    // Translated string data for a downloaded language translation.
+    "بيانات اللغة",
+
+    // Title shown in the prompt when deleting a type of app data.
+    "حذف",
+
+    // Prompt shown when deleting a type of app data. The type (one of the four listed above) is shown below this text.
+    "حذف هذا العنصر؟\n",
+
+    // Title for dialog box shown when opening an URL on a device that does not support running an app at the same time as the browser.
+    "فتح المتصفح",
+
+    // Text shown in that dialog box.
+    "هل تريد/ين فتح متصفح الويب؟ هذا سيغلق التطبيق.",
+
+    // Settings option for enabling custom menu scrolling handler. When this is enabled, holding up or down on the d-pad will scroll through menus by one menu item every 50 milliseconds, which is faster than the default scrolling speed on most devices.
+    "التمرير السريع",
+
+    // Error message shown when the notification sound failed to be played, usually because the device does not support the sound's file format.
+    "فشل تشغيل الصوت. قد يكون نوع الملف غير مدعوم.",
+
+    // Related to "Lines shown in the about screen for which language" above.
+    "اليابانية",
+    "الكاتالونية"
+]


### PR DESCRIPTION
Translated into Arabic.
``` Native name
العربية
```
No, I didn't integrate it into the list, just translated en.jsonc :/
For the flag, use either the Arab League flag or the Saudi Arabia one.
P.S. I am unable to compile anything right now, so please compile it for me to test it myself :p