### PR TITLE
Update pl.jsonc

### DIFF
--- a/language/pl.jsonc
+++ b/language/pl.jsonc
@@ -595,7 +595,7 @@
     "",
 
     // Settings option for using nnproject's Pigler Notifications API (extension API for showing notifications in the notification panel on Symbian Belle) for message notifications. The name "Pigler" should not be translated.
-    "Pigler API",
+    null,
 
     // Prefix for error messages related to Pigler Notifications API.
     "Błąd Pigler API: ",
@@ -683,8 +683,8 @@
 
     // Units for attachment sizes.
     " bajtów",
-    " kB",
-    " MB",
+    null,
+    null,
 
     // Softkey labels for opening the thread list of a channel in the channel list.
     "Wątki",
@@ -699,7 +699,7 @@
     "Zmień token",
 
     // Option in notification settings for using Nokia UI API for notifications.
-    "Nokia UI",
+    null,
 
     // Option in notification settings for using Nokia UI API for notifications. This variant of the option is shown on J2ME Loader, because J2ME Loader shows Nokia UI notifications as Android notifications in the notification panel.
     "Powiadomienia na Androidzie",

--- a/language/pl.jsonc
+++ b/language/pl.jsonc
@@ -636,7 +636,7 @@
     // The name of the person in question is shown above each line.
     "Główny twórca",
     "Wczytywanie załączników, integracja Pigler API, parser JSON",
-    "Animacja wczytywania, ikony menu, włoskie tłumaczenie",
+    "Animacja wczytywania, ikony menu oraz emotikon, włoskie tłumaczenie",
 
     // Lines shown in the about screen for which language(s) each person wrote translations for.
     // Note: These are ordered alphabetically based on the person's name, not the language's name


### PR DESCRIPTION
- "Pigler API" and "Nokia UI" API name and file size unit strings (kB and above) are now fetched from the reference (english) language since they are the same (replaced with `null`)
- Included info about Saetta's emoji art in credits